### PR TITLE
Scala-like underscore for lambda expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE
+.vscode
+.idea

--- a/lazy/lazy.py
+++ b/lazy/lazy.py
@@ -1,0 +1,45 @@
+def is_callable(x):
+    return hasattr(x, '__call__')
+
+
+def value_function(value):
+    return lambda x: value
+
+
+class Underscore(object):
+    def __init__(self, value):
+        self.f = is_callable(value) and value or value_function(value)
+
+    def __call__(self, *args, **kargs):
+        return self.f(*args)
+
+    def __add__(self, other):
+        f = lambda x: self.f(x) + Underscore(other)(x)
+        return Underscore(f)
+
+    def __radd__(self, other):
+        f = lambda x: Underscore(other)(x) + self.f(x)
+        return Underscore(f)
+
+    def __mul__(self, other):
+        f = lambda x: self.f(x) * Underscore(other)(x)
+        return Underscore(f)
+
+    def __rmul__(self, other):
+        f = lambda x: Underscore(other)(x) * self.f(x)
+        return Underscore(f)
+
+
+def F(f):
+    def function(*args, **kargs):
+        args = [Underscore(v) for v in args]
+        kargs = {k: Underscore(v) for k, v in kargs.items()}
+        return lambda x: f(
+            *[arg(x) for arg in args],
+            **{k: v(x) for k, v in kargs.items()}
+        )
+
+    return function
+
+
+_ = Underscore(lambda x: x)

--- a/lazy/test_underscore.py
+++ b/lazy/test_underscore.py
@@ -1,0 +1,49 @@
+from .lazy import _, F
+
+
+def test_underscore_calculate():
+    f = _
+    assert f(4) == 4
+
+    f = _ + 2
+    assert f(4) == 6
+
+    f = 4 + _
+    assert f(1) == 5
+
+    f = 6 + _ + 2
+    assert f(1) == 9
+
+    f = 2 * (6 + _ * 2)
+    assert f(4) == 28
+
+    f = _ + _
+    assert f(4) == 8
+
+    f = 3 * _ + _ * 2
+    assert f(4) == 20
+
+    assert list(map(_ * 2, [1, 2, 3])) == [2, 4, 6]
+
+
+def test_underscore_with_functions():
+    def add(x, y):
+        return x + y
+
+    f = F(str)(_ + 3)
+    assert f(2) == "5"
+
+    f = F(add)(_, 3)
+    assert f(2) == 5
+
+    f = F(add)(x=_, y=3)
+    assert f(2) == 5
+
+    f = F(add)(_, y=3)
+    assert f(2) == 5
+
+    assert list(map(F(str)(_ * 2), [1, 2, 3])) == ['2', '4', '6']
+    assert list(map(F(str)(_ * _), [1, 2, 3])) == ['1', '4', '9']
+    assert list(map(F(add)(1, _ * 2), [1, 2, 3])) == [3, 5, 7]
+    assert list(map(F(add)(_ * 2, 4), [1, 2, 3])) == [6, 8, 10]
+    assert list(map(F(add)(_ * 3, _ + 2), [1, 2, 3])) == [6, 10, 14]


### PR DESCRIPTION
Make Scala-like underscore(`_`) to use `lambda` expression easier.

Issue: https://github.com/Las-Wonho/LazyPython/issues/16